### PR TITLE
Remove sbt 0.13.13 deprecation warning (issue #3)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,4 +12,4 @@ scalaVersion := "2.11.8"
 
 nativeClangOptions ++= Seq("-L" ++ baseDirectory.value.getAbsolutePath() ++ "/target")
 
-compile in Compile := (compile in Compile dependsOn make).value
+compile in Compile <<= (compile in Compile).dependsOn(make)

--- a/build.sbt
+++ b/build.sbt
@@ -12,4 +12,4 @@ scalaVersion := "2.11.8"
 
 nativeClangOptions ++= Seq("-L" ++ baseDirectory.value.getAbsolutePath() ++ "/target")
 
-compile in Compile <<= (compile in Compile).dependsOn(make)
+compile in Compile := (compile in Compile dependsOn make).value


### PR DESCRIPTION
This edit removes use of the now (sbt 0.13.13) deprecated ```<<=``` operator and
replaces the line with current syntax. 

The obsolete operator had been causing an sbt warning. Now sbt loads without
warnings.  