### PR TITLE
Remove use of now deprecated <<= operator & re-work line (fixes issue #3) 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,4 +12,4 @@ scalaVersion := "2.11.8"
 
 nativeClangOptions ++= Seq("-L" ++ baseDirectory.value.getAbsolutePath() ++ "/target")
 
-compile in Compile <<= (compile in Compile).dependsOn(make)
+compile in Compile := (compile in Compile dependsOn make).value


### PR DESCRIPTION
###### Prior behaviour:
   sbt 0.13.13 issued a deprecation warning about the use of the now deprecated <<= operator

###### Current behaviour:
   sbt 0.13.13 loads project build.sbt cleanly, without warnings.